### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Personal take on what a GPG UI should look like
 ## Prerequisites
 
 - `python3-setuptools` (`sudo apt-get install python3-setuptools`)
-- `python3-gnutls` (`sudo apt-get install python3-gnutls`)
+- `python3-gnupg` (`sudo apt-get install python3-gnupg`)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Personal take on what a GPG UI should look like
 ### Using setuputils
 
 - Clone repo
-- `sudo setup.py install`
+- `sudo ./setup.py install`
 
 ## Running
 


### PR DESCRIPTION
- `setup.py` must be called like `./setup.py`.
- `python3-gnutls` does not exist in the Debian repositories. From what I can tell this seems to be a mistake in the readme; it should be `python3-gnupg`.
